### PR TITLE
Fix assumed return type of MSVC

### DIFF
--- a/src/library/os/os.c
+++ b/src/library/os/os.c
@@ -88,6 +88,8 @@ FUNCTION_RETURN verifySignature(const char* stringToVerify,
 #include <Windows.h>
 #pragma comment(lib, "IPHLPAPI.lib")
 
+unsigned char* unbase64(const char* ascii, int len, int *flen);
+
 static void printHash(HCRYPTHASH* hHash) {
 	BYTE *pbHash;
 	DWORD dwHashLen;


### PR DESCRIPTION
With unbase64() undeclared, MSVS will assume the return type is int
while it should be a pointer. int is 32 bit and pointer is 64 bit on
Win64 platform. Without this patch, it will fail in Win64 environment.