### PR TITLE
Small build fix for Debian 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ cmake_policy(SET CMP0048 NEW)
 #cmake_policy(SET CMP0091 NEW)
 project (licensecc 
 			VERSION 2.0.0
-			DESCRIPTION "Copy protection and licensing library" 
 			LANGUAGES CXX)
+set(PROJECT_DESCRIPTION "Copy protection and licensing library")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Use CMake PROJECT_DESCRIPTION var instead to be able to build with cmake < 3.8