### PR TITLE
Update SimpleIni.h

### DIFF
--- a/src/library/ini/SimpleIni.h
+++ b/src/library/ini/SimpleIni.h
@@ -217,7 +217,8 @@
 #include <map>
 #include <list>
 #include <algorithm>
-#include <stdio.h>
+#include <cstdio>
+#include <functional>
 
 #ifdef SI_SUPPORT_IOSTREAMS
 # include <iostream>


### PR DESCRIPTION
FIX std::binary_function not found on MSVC (VisualStudio 2022)