### PR TITLE
Fix license signature didn't match with current license on windows

### DIFF
--- a/src/inspector/inspector.cpp
+++ b/src/inspector/inspector.cpp
@@ -65,7 +65,7 @@ static LCC_EVENT_TYPE verifyLicense(const string& fname) {
 	ini.LoadFile(fname.c_str());
 	CSimpleIniA::TNamesDepend sections;
 	ini.GetAllSections(sections);
-	CallerInformations callerInformation;
+	CallerInformations callerInformation {"\0"};
 	for (CSimpleIniA::Entry section : sections) {
 		const string section_name(section.pItem, 15);
 		if (section_name != LCC_PROJECT_NAME) {


### PR DESCRIPTION
Fix license signature didn't match with current license on windows