### PR TITLE
remove deprecated std::binary_function inheritance

### DIFF
--- a/src/library/ini/SimpleIni.h
+++ b/src/library/ini/SimpleIni.h
@@ -326,7 +326,7 @@ public:
 #endif
 
         /** Strict less ordering by name of key only */
-        struct KeyOrder : std::binary_function<Entry, Entry, bool> {
+        struct KeyOrder {
             bool operator()(const Entry & lhs, const Entry & rhs) const {
                 const static SI_STRLESS isLess = SI_STRLESS();
                 return isLess(lhs.pItem, rhs.pItem);
@@ -334,7 +334,7 @@ public:
         };
 
         /** Strict less ordering by order, and then name of key */
-        struct LoadOrder : std::binary_function<Entry, Entry, bool> {
+        struct LoadOrder {
             bool operator()(const Entry & lhs, const Entry & rhs) const {
                 if (lhs.nOrder != rhs.nOrder) {
                     return lhs.nOrder < rhs.nOrder;


### PR DESCRIPTION
Update KeyOrder and LoadOrder to no longer inherit from std::binary_function,
ensuring compatibility with C++17 and later. Behaviour is unchanged.