### PR TITLE
Add custom client signature validation API

### DIFF
--- a/include/licensecc/licensecc.h
+++ b/include/licensecc/licensecc.h
@@ -14,6 +14,30 @@ extern "C" {
 #include "datatypes.h"
 
 /**
+ * \brief Sets a custom validator for client signature (host ID) validation.
+ * 
+ * This allows applications to provide their own host ID validation logic
+ * instead of using licensecc's built-in hardware identification.
+ * 
+ * @param validator Function pointer that takes a client signature string and returns true if valid
+ * @return true if the validator was set successfully, false if already set
+ * 
+ * Note: Can only be set once. Subsequent calls will fail to prevent tampering.
+ * 
+ * Example usage:
+ * ```c
+ * bool my_host_validator(const char* client_sig) {
+ *     // Custom validation logic
+ *     return validate_apra_hostid(client_sig);
+ * }
+ * 
+ * set_client_signature_validator(my_host_validator);
+ * ```
+ */
+typedef bool (*ClientSignatureValidator)(const char* client_signature);
+bool set_client_signature_validator(ClientSignatureValidator validator);
+
+/**
  * Method used to convert the LicenseInfo into a human readable
  * representation.
  */

--- a/src/library/limits/license_verifier.cpp
+++ b/src/library/limits/license_verifier.cpp
@@ -13,6 +13,20 @@
 #include "../os/signature_verifier.hpp"
 #include "../hw_identifier/hw_identifier_facade.hpp"
 
+// Custom client signature validation callback
+typedef bool (*ClientSignatureValidator)(const char* client_signature);
+static ClientSignatureValidator g_client_signature_validator = nullptr;
+static bool g_validator_locked = false;
+
+extern "C" bool set_client_signature_validator(ClientSignatureValidator validator) {
+    if (g_validator_locked) {
+        return false;  // Already set, prevent changes
+    }
+    g_client_signature_validator = validator;
+    g_validator_locked = true;
+    return true;
+}
+
 namespace license {
 using namespace std;
 
@@ -57,7 +71,18 @@ FUNCTION_RETURN LicenseVerifier::verify_limits(const FullLicenseInfo& lic_info) 
 	}
 	const auto client_sig = lic_info.m_limits.find(PARAM_CLIENT_SIGNATURE);
 	if (is_valid && client_sig != lic_info.m_limits.end()) {
-		const LCC_EVENT_TYPE event = hw_identifier::HwIdentifierFacade::validate_pc_signature(client_sig->second);
+		LCC_EVENT_TYPE event;
+		
+		// Use custom validator if set, otherwise use default
+		if (g_client_signature_validator != nullptr) {
+			// Delegate to custom validator
+			bool valid = g_client_signature_validator(client_sig->second.c_str());
+			event = valid ? LICENSE_OK : IDENTIFIERS_MISMATCH;
+		} else {
+			// Use default licensecc validation
+			event = hw_identifier::HwIdentifierFacade::validate_pc_signature(client_sig->second);
+		}
+		
 		m_event_registry.addEvent(event, lic_info.source);
 		is_valid = is_valid && (event == LICENSE_OK);
 	}


### PR DESCRIPTION
Implements a flexible client signature (host ID) validation system that allows applications to provide their own host identification logic instead of relying solely on licensecc's built-in hardware fingerprinting.

Key features:
- Added set_client_signature_validator() API function to register custom validators
- Custom validator receives the client signature string from the license file
- Validator returns boolean indicating whether the signature is valid
- One-time-only registration to prevent runtime tampering (locked after first set)
- Falls back to default licensecc hardware validation if no custom validator set
- Maintains backward compatibility - existing code works without changes

API additions:
- ClientSignatureValidator typedef for validator function signature
- set_client_signature_validator() function in licensecc.h public API
- Thread-safe implementation using static locked flag

Use cases:
- Cloud/virtualized environments where hardware IDs change
- Custom hardware identification schemes (e.g., USB dongles, TPM chips)
- Enterprise environments with centralized license servers
- Testing/development with mocked host validation

This feature enables more flexible licensing models while maintaining security through the one-time registration constraint.